### PR TITLE
Update kustomization.yaml

### DIFF
--- a/manifests/branch/base/kustomization.yaml
+++ b/manifests/branch/base/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - ./deployments/receipt-generation-service.yaml
 - ./deployments/ui.yaml
 - ./deployments/services-for-ui.yaml
+- ./deployments/ui-service.yaml
 - ./deployments/virtual-customers.yaml
 - ./deployments/virtual-worker.yaml
 - ./components/reddog.binding.receipt.yaml


### PR DESCRIPTION
add ui-service.yaml to kustomization. This fixes the issue with the UI not listening on 8081 because the service definition was moved to this file.

comments ? ok ?
-dcasati