### PR TITLE
remove traefik from k3s

### DIFF
--- a/infra/branch/bicep/modules/k3s/control.bicep
+++ b/infra/branch/bicep/modules/k3s/control.bicep
@@ -14,7 +14,7 @@ var customData = base64(format('''
 #cloud-config
 package_upgrade: true
 runcmd:
-  - curl -sfL https://get.k3s.io | K3S_TOKEN={0} sh -s -
+  - curl -sfL https://get.k3s.io | K3S_TOKEN={0} INSTALL_K3S_EXEC="server --disable traefik" sh -s -
 ''',k3sToken))
 
 param name string


### PR DESCRIPTION
removes Traefik from the k3s nodes (on the branches). Reason: to accommodate the Envoy install later in the deployment.